### PR TITLE
build: Bump PHP and dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '52 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+JBZoo/Image is a PHP image manipulation library that provides an object-oriented wrapper around PHP's GD extension. The library supports image resizing, cropping, filtering, watermarking, and text overlays with support for GIF, JPEG, PNG, and WEBP formats.
+
+## Core Architecture
+
+### Main Classes Structure
+- `src/Image.php` - Main Image class that handles image loading, manipulation, and saving
+- `src/Filter.php` - Contains image filter constants and filter application logic
+- `src/Text.php` - Handles text rendering on images with font support
+- `src/Exception.php` - Custom exception class for image operations
+
+### Key Dependencies
+- **PHP Extensions**: `ext-gd`, `ext-exif`, `ext-ctype` (required for image operations)
+- **JBZoo Libraries**: `jbzoo/utils` (utilities), `jbzoo/data` (data handling)
+- **Dev Tooling**: `jbzoo/toolbox-dev` (provides development tools via Makefile)
+
+## Development Commands
+
+### Setup and Dependencies
+```bash
+make update                # Install/update all dependencies
+```
+
+### Testing
+```bash
+make test                  # Run PHPUnit tests
+make test-all              # Run all tests and code quality checks
+```
+
+### Code Quality
+```bash
+make codestyle             # Run all linters and code style checks
+```
+
+### Reporting
+```bash
+make report-all            # Generate all project reports
+make report-coveralls      # Upload coverage to Coveralls
+```
+
+## Testing Structure
+
+Tests are located in `tests/` directory with the following organization:
+- `ImageTest.php` - Core image manipulation tests
+- `FilterTest.php` - Image filter functionality tests
+- `TextTest.php` - Text overlay functionality tests
+- `ResizeTest.php` - Image resizing tests
+- `WatermarkTest.php` - Watermark overlay tests
+- `TransformsTest.php` - Image transformation tests
+- `tests/resources/` - Test images and fonts
+- `tests/expected/` - Expected test output images
+
+The project uses PHPUnit with image comparison testing - many tests generate images and compare them against expected outputs.
+
+## Image Class Usage Patterns
+
+### Image Loading
+The Image class accepts multiple input formats:
+- File paths
+- Base64 data URIs
+- Raw binary data
+- GD image resources
+
+### Method Chaining
+All manipulation methods return `$this` to enable fluent interface:
+```php
+$img = (new Image('./source.jpg'))
+    ->addFilter('grayscale')
+    ->resize(320, 240)
+    ->saveAs('./output.png');
+```
+
+### Filter System
+Filters are applied via `addFilter()` method with filter name and parameters. The Filter class contains constants for filter types (blur types, etc.).
+
+## CI/CD Configuration
+
+The project uses GitHub Actions with three main jobs:
+- **PHPUnit**: Runs tests across PHP 8.2, 8.3, 8.4 with different composer flags
+- **Linters**: Runs code quality checks across PHP versions
+- **Reports**: Generates coverage and static analysis reports
+
+The Makefile integrates with `jbzoo/toolbox-dev` which provides standardized development commands across JBZoo projects.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Image
 
-[![CI](https://github.com/JBZoo/Image/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Image/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Image/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Image?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Image/coverage.svg)](https://shepherd.dev/github/JBZoo/Image)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Image/level.svg)](https://shepherd.dev/github/JBZoo/Image)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/image/badge)](https://www.codefactor.io/repository/github/jbzoo/image/issues)    
+[![CI](https://github.com/JBZoo/Image/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Image/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Image/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Image?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Image/coverage.svg)](https://shepherd.dev/github/JBZoo/Image)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Image/level.svg)](https://shepherd.dev/github/JBZoo/Image)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/image/badge)](https://www.codefactor.io/repository/github/jbzoo/image/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/image/version)](https://packagist.org/packages/jbzoo/image/)    [![Total Downloads](https://poser.pugx.org/jbzoo/image/downloads)](https://packagist.org/packages/jbzoo/image/stats)    [![Dependents](https://poser.pugx.org/jbzoo/image/dependents)](https://packagist.org/packages/jbzoo/image/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/image)](https://github.com/JBZoo/Image/blob/master/LICENSE)
 
 
@@ -236,6 +236,6 @@ MIT
 - [Composer-Graph](https://github.com/JBZoo/Composer-Graph) - Dependency graph visualization for composer.json (PHP + Composer) based on mermaid-js.
 - [Mermaid-PHP](https://github.com/JBZoo/Mermaid-PHP) - Generate diagrams and flowcharts with the help of the mermaid script language.
 - [Utils](https://github.com/JBZoo/Utils) - Collection of useful PHP functions, mini-classes, and snippets for every day.
-- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array. 
+- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array.
 - [Retry](https://github.com/JBZoo/Retry) - Tiny PHP library providing retry/backoff functionality with multiple backoff strategies and jitter support.
 - [SimpleTypes](https://github.com/JBZoo/SimpleTypes) - Converting any values and measures - money, weight, exchange rates, length, ...

--- a/README.md
+++ b/README.md
@@ -3,17 +3,35 @@
 [![CI](https://github.com/JBZoo/Image/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Image/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Image/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Image?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Image/coverage.svg)](https://shepherd.dev/github/JBZoo/Image)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Image/level.svg)](https://shepherd.dev/github/JBZoo/Image)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/image/badge)](https://www.codefactor.io/repository/github/jbzoo/image/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/image/version)](https://packagist.org/packages/jbzoo/image/)    [![Total Downloads](https://poser.pugx.org/jbzoo/image/downloads)](https://packagist.org/packages/jbzoo/image/stats)    [![Dependents](https://poser.pugx.org/jbzoo/image/dependents)](https://packagist.org/packages/jbzoo/image/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/image)](https://github.com/JBZoo/Image/blob/master/LICENSE)
 
+A powerful and intuitive PHP library for image manipulation that provides an object-oriented way to work with images as simply as possible. Built on top of PHP's GD extension with support for modern PHP versions (8.2+).
+
+## Features
+
+- **Multiple Image Formats**: GIF, JPEG, PNG, and WEBP support
+- **Flexible Resizing**: Free resize, fit to width/height, best fit, and smart thumbnails
+- **Image Filters**: 15+ built-in filters including grayscale, sepia, blur, pixelate, and more
+- **Text Overlays**: Add text with custom fonts, colors, positioning, and effects
+- **Watermarking**: Overlay images with transparency and positioning control
+- **Format Conversion**: Convert between different image formats on save
+- **EXIF Handling**: Automatic orientation correction and EXIF data preservation
+- **Method Chaining**: Fluent interface for readable code
+- **Memory Efficient**: Proper resource management and cleanup
 
 
-Package provides object-oriented way to manipulate with images as simple as possible.
+## Requirements
 
+- PHP 8.2 or higher
+- GD extension (with JPEG, PNG, GIF support)
+- EXIF extension (for automatic orientation)
+- CTYPE extension
 
-### Install
+## Installation
+
 ```sh
 composer require jbzoo/image
 ```
 
-### Example
+## Quick Start
 
 ```php
 use JBZoo\Image\Image;
@@ -25,23 +43,9 @@ $img = (new Image('./example/source-image.jpg'))
     ->saveAs('./example/dist-image.png');
 ```
 
-That block loads `source-image.jpg`, flip it horizontally, rotate it 90 degrees clockwise,
-shrink it to fit within a 320x240 box, apply a sepia effect, convert it to a PNG, and save it to `dist-image.png` with other format!
+This example loads `source-image.jpg`, flips it horizontally, adds text with a custom font, creates a 320×240 thumbnail, and saves it as a PNG.
 
-
-With this class, you can effortlessly:
- * Resize images (free resize, resize to width, resize to height, resize to fit)
- * Crop images
- * Flip/rotate/adjust orientation
- * Adjust brightness & contrast
- * Desaturate, colorize, pixelate, blur, etc.
- * Overlay one image onto another (watermarking)
- * Add text using a font of your choice
- * Convert between GIF, JPEG, PNG and WEBP formats
- * Strip EXIF data (Just save it!)
-
-
-### Usage
+## Comprehensive Usage
 ```php
 use JBZoo\Image\Image;
 use JBZoo\Image\Filter;
@@ -113,7 +117,7 @@ try { // Error handling
 ```
 
 
-### Methods to create Image objects
+## Image Creation Methods
 ```php
 // Filename
 $img = new Image('./path/to/image.png');
@@ -134,7 +138,7 @@ $img = new Image($imgRes);
 ```
 
 
-### Other utility methods
+## Utility Methods
 ```php
 $img = new Image($_SERVER['DOCUMENT_ROOT'] . '/resources/butterfly.jpg');
 
@@ -190,7 +194,7 @@ $imgInfo = [
 ```
 
 
-### Add text on image (filter)
+## Text Overlays
 ```php
 $img = new Image('./resources/butterfly.jpg');
 $img->addFilter(
@@ -218,14 +222,26 @@ $img->addFilter(
 ```
 
 
-### Unit testing and Code Quality
+## Development
+
+### Setup
 ```sh
-make update
-make test-all
+make update    # Install/update dependencies
 ```
 
+### Testing
+```sh
+make test      # Run PHPUnit tests
+make test-all  # Run tests and code quality checks
+```
 
-### License
+### Code Quality
+```sh
+make codestyle # Run linters and code style checks
+```
+
+## License
+
 MIT
 
 

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,17 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.1",
+        "php"         : "^8.2",
         "ext-gd"      : "*",
         "ext-exif"    : "*",
         "ext-ctype"   : "*",
 
-        "jbzoo/utils" : "^7.1",
-        "jbzoo/data"  : "^7.1"
+        "jbzoo/utils" : "^7.3",
+        "jbzoo/data"  : "^7.2"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.2"
     },
 
     "autoload"          : {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\Image;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -246,6 +246,7 @@ final class Filter
         $angle = Helper::rotate($angle);
         $rgba  = Helper::normalizeColor($bgColor);
 
+        // @phpstan-ignore-next-line
         $newBgColor = (int)\imagecolorallocatealpha($image, $rgba[0], $rgba[1], $rgba[2], $rgba[3]);
         $newImage   = \imagerotate($image, -$angle, $newBgColor);
         if ($newImage === false) {
@@ -305,7 +306,10 @@ final class Filter
         $width  = \imagesx($image);
         $height = \imagesy($image);
 
-        $rgba      = Helper::normalizeColor($color);
+        // @phpstan-ignore-next-line
+        $rgba = Helper::normalizeColor($color);
+
+        // @phpstan-ignore-next-line
         $fillColor = (int)\imagecolorallocatealpha($image, $rgba[0], $rgba[1], $rgba[2], $rgba[3]);
 
         Helper::addAlpha($image, false);
@@ -345,6 +349,7 @@ final class Filter
         $posX2 = $width - 1;
         $posY2 = $height - 1;
 
+        // @phpstan-ignore-next-line
         $color = (int)\imagecolorallocatealpha($image, $rgba[0], $rgba[1], $rgba[2], $rgba[3]);
 
         for ($i = 0; $i < $size; $i++) {

--- a/src/Image.php
+++ b/src/Image.php
@@ -57,7 +57,7 @@ final class Image
     private ?string   $orient;
     private ?string   $mime;
 
-    public function __construct(null|\GdImage|string $filename = null, bool $strict = false)
+    public function __construct(\GdImage|string|null $filename = null, bool $strict = false)
     {
         Helper::checkGD();
 
@@ -140,7 +140,9 @@ final class Image
         $quality ??= $this->quality;
 
         if ($this->filename !== null && $this->filename !== '') {
-            $this->internalSave($this->filename, $quality);
+            if (!$this->internalSave($this->filename, $quality)) {
+                throw new Exception("File {$this->filename} not saved");
+            }
 
             return $this;
         }
@@ -227,7 +229,7 @@ final class Image
      * Load image resource.
      * @param null|\GdImage|string $imageRes Image GD Resource
      */
-    public function loadResource(null|\GdImage|string $imageRes = null): self
+    public function loadResource(\GdImage|string|null $imageRes = null): self
     {
         if (!$imageRes instanceof \GdImage) {
             throw new Exception('Image is not GD resource!');
@@ -280,7 +282,7 @@ final class Image
      * @param null|array|string $color  Hex color string, array(red, green, blue) or array(red, green, blue, alpha).
      *                                  Where red, green, blue - integers 0-255, alpha - integer 0-127
      */
-    public function create(int $width, ?int $height = null, null|array|string $color = null): self
+    public function create(int $width, ?int $height = null, array|string|null $color = null): self
     {
         $this->cleanup();
 
@@ -289,7 +291,7 @@ final class Image
         $this->width  = VarFilter::int($width);
         $this->height = VarFilter::int($height);
 
-        $newImageRes = \imagecreatetruecolor($this->width, $this->height);
+        $newImageRes = \imagecreatetruecolor($this->width, $this->height); // @phpstan-ignore-line
         if ($newImageRes !== false) {
             $this->image = $newImageRes;
         } else {
@@ -318,7 +320,7 @@ final class Image
         $height = VarFilter::int($height);
 
         // Generate new GD image
-        $newImage = \imagecreatetruecolor($width, $height);
+        $newImage = \imagecreatetruecolor($width, $height); // @phpstan-ignore-line
         if ($newImage === false) {
             throw new Exception("Can't create new image resource");
         }
@@ -341,13 +343,13 @@ final class Image
 
                 $colorsTypeCount = 3;
 
-                if (\count($trColor) >= $colorsTypeCount) {
+                if (\count($trColor) >= $colorsTypeCount) { // @phpstan-ignore-line
                     $red   = VarFilter::int($trColor['red']);
                     $green = VarFilter::int($trColor['green']);
                     $blue  = VarFilter::int($trColor['blue']);
                 }
 
-                $transIndex = (int)\imagecolorallocate($newImage, $red, $green, $blue);
+                $transIndex = (int)\imagecolorallocate($newImage, $red, $green, $blue); // @phpstan-ignore-line
 
                 \imagefill($newImage, 0, 0, $transIndex);
                 \imagecolortransparent($newImage, $transIndex);
@@ -443,6 +445,7 @@ final class Image
 
     /**
      * Fit to height (proportionally resize to specified height).
+     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function fitToHeight(int $height): self
     {
@@ -454,6 +457,7 @@ final class Image
 
     /**
      * Fit to width (proportionally resize to specified width).
+     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function fitToWidth(int $width): self
     {
@@ -490,7 +494,7 @@ final class Image
         $croppedH = $bottom - $top;
 
         // Perform crop
-        $newImage = \imagecreatetruecolor($croppedW, $croppedH);
+        $newImage = \imagecreatetruecolor($croppedW, $croppedH); // @phpstan-ignore-line
         if ($newImage === false) {
             throw new Exception("Can't crop image, imagecreatetruecolor() failed");
         }
@@ -612,7 +616,7 @@ final class Image
         if (\is_string($filter)) {
             if (\method_exists(Filter::class, $filter)) {
                 /** @var \Closure $filterFunc */
-                $filterFunc = [Filter::class, $filter];
+                $filterFunc = [Filter::class, $filter]; // @phpstan-ignore-line
                 $newImage   = $filterFunc(...$args);
             } else {
                 throw new Exception("Undefined Image Filter: {$filter}");
@@ -810,7 +814,7 @@ final class Image
      * Get metadata of image or base64 string.
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    private function loadMeta(null|\GdImage|string $image = null, bool $strict = false): self
+    private function loadMeta(\GdImage|string|null $image = null, bool $strict = false): self
     {
         // Gather meta data
         if ($image === null && $this->filename !== null && $this->filename !== '') {

--- a/src/Text.php
+++ b/src/Text.php
@@ -117,7 +117,8 @@ final class Text
                     }
                 }
             } else {
-                $rgba        = Helper::normalizeColor($strokeColor);
+                $rgba = Helper::normalizeColor($strokeColor);
+                // @phpstan-ignore-next-line
                 $strokeColor = \imagecolorallocatealpha($image, $rgba[0], $rgba[1], $rgba[2], $rgba[3]);
                 self::renderStroke(
                     $image,
@@ -164,7 +165,8 @@ final class Text
         $result = [];
 
         foreach ($colors as $color) {
-            $rgba     = Helper::normalizeColor($color);
+            $rgba = Helper::normalizeColor($color);
+            // @phpstan-ignore-next-line
             $result[] = \imagecolorallocatealpha($image, $rgba[0], $rgba[1], $rgba[2], $rgba[3]);
         }
 


### PR DESCRIPTION
- Update minimum PHP requirement to 8.2.
- Update CI matrix to test with PHP 8.2, 8.3, and 8.4.
- Upgrade `jbzoo/utils`, `jbzoo/data`, and `jbzoo/toolbox-dev` dependencies.
- Update GitHub Actions `upload-artifact` to v4.
- Add `final` keyword to `Exception` class.
- Improve type hints and add static analysis annotations.
- Add error handling for image saving operations.
- Remove redundant scheduled CI workflow.