### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,20 +37,20 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '${{ matrix.php-version }}'
-          coverage: '${{ matrix.coverage }}'
+          php-version: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}
           tools: composer
           extensions: ast
 
@@ -58,18 +61,19 @@ jobs:
         run: make test --no-print-directory
 
       - name: Uploading coverage to coveralls
-        if: "${{ matrix.coverage == 'xdebug' }}"
+        if: '${{ matrix.coverage == ''xdebug'' }}'
         continue-on-error: true
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,17 +81,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '${{ matrix.php-version }}'
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer
           extensions: ast
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Filters are applied via `addFilter()` method with filter name and parameters. Th
 ## CI/CD Configuration
 
 The project uses GitHub Actions with three main jobs:
-- **PHPUnit**: Runs tests across PHP 8.2, 8.3, 8.4 with different composer flags
+- **PHPUnit**: Runs tests across PHP 8.3, 8.4, 8.5 with different composer flags
 - **Linters**: Runs code quality checks across PHP versions
 - **Reports**: Generates coverage and static analysis reports
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # JBZoo / Image
 
-[![CI](https://github.com/JBZoo/Image/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Image/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Image/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Image?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Image/coverage.svg)](https://shepherd.dev/github/JBZoo/Image)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Image/level.svg)](https://shepherd.dev/github/JBZoo/Image)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/image/badge)](https://www.codefactor.io/repository/github/jbzoo/image/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/image/version)](https://packagist.org/packages/jbzoo/image/)    [![Total Downloads](https://poser.pugx.org/jbzoo/image/downloads)](https://packagist.org/packages/jbzoo/image/stats)    [![Dependents](https://poser.pugx.org/jbzoo/image/dependents)](https://packagist.org/packages/jbzoo/image/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/image)](https://github.com/JBZoo/Image/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Image/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Image/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Image/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Image?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Image/coverage.svg)](https://shepherd.dev/github/JBZoo/Image)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Image/level.svg)](https://shepherd.dev/github/JBZoo/Image)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/image/badge)](https://www.codefactor.io/repository/github/jbzoo/image/issues)
 
-A powerful and intuitive PHP library for image manipulation that provides an object-oriented way to work with images as simply as possible. Built on top of PHP's GD extension with support for modern PHP versions (8.2+).
+[![Stable Version](https://poser.pugx.org/jbzoo/image/version)](https://packagist.org/packages/jbzoo/image/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/image/downloads)](https://packagist.org/packages/jbzoo/image/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/image/dependents)](https://packagist.org/packages/jbzoo/image/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/image)](https://github.com/JBZoo/Image/blob/master/LICENSE)
+
+A powerful and intuitive PHP library for image manipulation that provides an object-oriented way to work with images as simply as possible. Built on top of PHP's GD extension with support for modern PHP versions (8.3+).
 
 ## Features
 
@@ -20,7 +28,7 @@ A powerful and intuitive PHP library for image manipulation that provides an obj
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - GD extension (with JPEG, PNG, GIF support)
 - EXIF extension (for automatic orientation)
 - CTYPE extension

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,17 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.2",
+        "php"         : "^8.3",
         "ext-gd"      : "*",
         "ext-exif"    : "*",
         "ext-ctype"   : "*",
 
-        "jbzoo/utils" : "^7.3",
-        "jbzoo/data"  : "^7.2"
+        "jbzoo/utils" : "^8.0",
+        "jbzoo/data"  : "^8.0"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.2"
+        "jbzoo/toolbox-dev" : "^8.0"
     },
 
     "autoload"          : {
@@ -65,7 +65,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,25 +10,14 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Image
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+<phpunit bootstrap="tests/autoload.php"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         verbose="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -45,4 +34,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -220,8 +220,6 @@ final class Filter
                     $opacity,
                 );
 
-                \imagedestroy($image);
-
                 return $newImage;
             }
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -312,7 +312,6 @@ final class Image
 
     /**
      * Resize an image to the specified dimensions.
-     * @phan-suppress PhanPossiblyFalseTypeArgumentInternal
      */
     public function resize(float $width, float $height): self
     {
@@ -445,7 +444,6 @@ final class Image
 
     /**
      * Fit to height (proportionally resize to specified height).
-     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function fitToHeight(int $height): self
     {
@@ -457,7 +455,6 @@ final class Image
 
     /**
      * Fit to width (proportionally resize to specified width).
-     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public function fitToWidth(int $width): self
     {
@@ -882,7 +879,6 @@ final class Image
     private function destroyImage(): void
     {
         if ($this->image instanceof \GdImage) {
-            \imagedestroy($this->image);
             $this->image = null;
         }
     }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -341,9 +341,7 @@ class ImageTest extends PHPUnit
         isSame('', $img->getUrl());
     }
 
-    /**
-     * @requires PHP 5.4
-     */
+    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 5.4')]
     public function testOpenAsString(): void
     {
         $imgStr = 'R0lGODlhEAAQAOZeAHBwcKCgoOraIvDw8Mu9Hi4rBvPFJvTKJpyRF/bXJfPAJ/jeJU5IC0B'
@@ -499,9 +497,7 @@ class ImageTest extends PHPUnit
         $img->loadResource('');
     }
 
-    /**
-     * @requires PHP 5.4
-     */
+    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 5.4')]
     public function testInvalidImageString(): void
     {
         try {

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -25,3 +25,10 @@ if ($autoload = \realpath(ROOT_PATH . '/vendor/autoload.php')) {
     echo 'Please execute "composer update" !' . \PHP_EOL;
     exit(1);
 }
+
+// Tests write generated images to ./build/images. The Makefile "update" target also creates it,
+// but running PHPUnit directly (as the hermetic gate does) must not depend on that side effect.
+$buildImagesDir = ROOT_PATH . '/build/images';
+if (!\is_dir($buildImagesDir)) {
+    \mkdir($buildImagesDir, 0777, true);
+}


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.

### Changed (internal, behaviour-preserving)
- Removed no-op `imagedestroy()` calls (no effect since PHP 8.0) and an always-true `imagesetpixel` return check — required to satisfy phan on 8.5; no observable effect.
